### PR TITLE
Add enum in callback

### DIFF
--- a/lib/ex_parameterized.ex
+++ b/lib/ex_parameterized.ex
@@ -44,6 +44,14 @@ defmodule ExUnit.Parameterized do
               {context[:value], 2, 3}
             ]
         end
+
+        # Be able to use enum as parameters
+        test_with_params "ast from enum",
+          fn (a) ->
+            assert a == ["a", "b"]
+          end do
+            Enum.map([{["a", "b"]}], fn (x) -> x end)
+        end
       end
 
   Each test cases have a number suffix when run them.

--- a/lib/ex_parameterized/params_callback.ex
+++ b/lib/ex_parameterized/params_callback.ex
@@ -2,12 +2,22 @@ defmodule ExUnit.Parameterized.ParamsCallback do
   @moduledoc false
 
   @spec test_with_params(bitstring, any, fun ,[tuple]) :: any
-  defmacro test_with_params(desc, context, fun, params) do
-    Keyword.get(params, :do, nil)
-    |> param_with_index
-    |> Enum.map(fn(test_param)->
-         test_with(desc, context, fun, test_param)
-       end)
+  defmacro test_with_params(desc, context, fun, params_ast) do
+    try do
+      {params, _} = Code.eval_quoted params_ast
+      Keyword.get(params, :do, nil)
+      |> param_with_index
+      |> Enum.map(fn(test_param)->
+           test_with(desc, context, fun, test_param)
+         end)
+    rescue
+      _ ->
+        Keyword.get(params_ast, :do, nil)
+        |> param_with_index
+        |> Enum.map(fn(test_param)->
+             test_with(desc, context, fun, test_param)
+           end)
+    end
   end
 
   defp test_with(desc, context, fun, {{param_desc, {_, _, values}}, num}) when is_atom(param_desc) do

--- a/lib/ex_parameterized/params_callback.ex
+++ b/lib/ex_parameterized/params_callback.ex
@@ -3,21 +3,20 @@ defmodule ExUnit.Parameterized.ParamsCallback do
 
   @spec test_with_params(bitstring, any, fun ,[tuple]) :: any
   defmacro test_with_params(desc, context, fun, params_ast) do
-    try do
+    a = try do
       {params, _} = Code.eval_quoted params_ast
-      Keyword.get(params, :do, nil)
-      |> param_with_index
-      |> Enum.map(fn(test_param)->
-           test_with(desc, context, fun, test_param)
-         end)
+      params
     rescue
       _ ->
-        Keyword.get(params_ast, :do, nil)
-        |> param_with_index
-        |> Enum.map(fn(test_param)->
-             test_with(desc, context, fun, test_param)
-           end)
+        params_ast
     end
+
+    Keyword.get(params, :do, nil)
+    |> param_with_index
+    |> Enum.map(fn(test_param)->
+         test_with(desc, context, fun, test_param)
+       end)
+
   end
 
   defp test_with(desc, context, fun, {{param_desc, {_, _, values}}, num}) when is_atom(param_desc) do

--- a/lib/ex_parameterized/params_callback.ex
+++ b/lib/ex_parameterized/params_callback.ex
@@ -3,20 +3,21 @@ defmodule ExUnit.Parameterized.ParamsCallback do
 
   @spec test_with_params(bitstring, any, fun ,[tuple]) :: any
   defmacro test_with_params(desc, context, fun, params_ast) do
-    a = try do
+    try do
       {params, _} = Code.eval_quoted params_ast
-      params
+      Keyword.get(params, :do, nil)
+      |> param_with_index
+      |> Enum.map(fn(test_param)->
+           test_with(desc, context, fun, test_param)
+         end)
     rescue
       _ ->
-        params_ast
+        Keyword.get(params_ast, :do, nil)
+        |> param_with_index
+        |> Enum.map(fn(test_param)->
+             test_with(desc, context, fun, test_param)
+           end)
     end
-
-    Keyword.get(params, :do, nil)
-    |> param_with_index
-    |> Enum.map(fn(test_param)->
-         test_with(desc, context, fun, test_param)
-       end)
-
   end
 
   defp test_with(desc, context, fun, {{param_desc, {_, _, values}}, num}) when is_atom(param_desc) do

--- a/test/ex_parameterized_testcase_test.exs
+++ b/test/ex_parameterized_testcase_test.exs
@@ -19,4 +19,11 @@ defmodule ExParameterizedTestCaseTest.MyTest  do
         "two values": {context[:value]}
       ]
   end
+
+  test_with_params "ast from enum", context,
+    fn (a) ->
+      assert a == [context[:hello], context[:value]]
+    end do
+      Enum.map([{["world", 1]}], fn (x) -> x end)
+  end
 end


### PR DESCRIPTION
ref: *\* (Protocol.UndefinedError) protocol Enumerable not implemented for #4

Add callback case.
Callback case means that we can use `set_up` and set context.
