### PR TITLE
Fix unused variable warnings and typo

### DIFF
--- a/lib/ex_parameterized/params.ex
+++ b/lib/ex_parameterized/params.ex
@@ -54,7 +54,7 @@ defmodule ExUnit.Parameterized.Params do
   defp param_with_index(list) when is_list(list) do
     Enum.zip(list, 0..Enum.count(list))
   end
-  defp param_with_index(list) do
+  defp param_with_index(_) do
     raise(ArgumentError, message: "Unsupported format")
   end
 end

--- a/lib/ex_parameterized/params_callback.ex
+++ b/lib/ex_parameterized/params_callback.ex
@@ -57,7 +57,7 @@ defmodule ExUnit.Parameterized.ParamsCallback do
   defp param_with_index(list) when is_list(list) do
     Enum.zip(list, 0..Enum.count(list))
   end
-  defp param_with_index(list) do
+  defp param_with_index(_) do
     raise(ArgumentError, message: "Unsupported format")
   end
 end

--- a/test/ex_parameterized_callback_test.exs
+++ b/test/ex_parameterized_callback_test.exs
@@ -38,7 +38,7 @@ defmodule ExParameterizedParamsCallbackTest do
              """)
   end
 
-  @tag skip: "If failed to skip, test will fai"
+  @tag skip: "If failed to skip, test will fail"
   test_with_params "skipped test with context", context, fn a ->
     assert a == true
   end do


### PR DESCRIPTION
Hi,
I had the following warnings when using your lib, so here is a PR to fix them.

```
warning: variable "list" is unused
  lib/ex_parameterized/params.ex:57

warning: variable "list" is unused
  lib/ex_parameterized/params_callback.ex:60
```